### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: true
+dist: trusty
+language: python
+python:
+  - "3.5"
+jobs:
+  include:
+    # trigger systemtests build only when pushing to master branch
+    - if: branch = master
+      script:
+        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
+        - travis_wait 60 python trigger_systemtests.py --adapter su2 --wait
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<a style="text-decoration: none" href="https://travis-ci.org/precice/su2-adapter" target="_blank">
+    <img src="https://travis-ci.org/precice/su2-adapter.svg?branch=master" alt="Build status">
+</a>
 
 # Building and Usage of the preCICE Adapter for SU2
 


### PR DESCRIPTION
#### This continues series of pull requests to add CI to adapters ( see [original idea](https://github.com/precice/systemtests/pull/22) and [openfoam-adapter pr](https://github.com/precice/openfoam-adapter/pull/65) )

As  described in detail in this  [pull request]( https://github.com/precice/systemtests/pull/22 ) for systemtests, it is now possible for an adapter to trigger custom set of tests on the [systemtests](https://github.com/precice/systemtests) repository. Therefore I add simple Travis set up that will test SU2-CalculiX coupling coupling and building of the solvers and adapters, that are involved. 

Given that this adapter is not updated so often, I also add monthly cron job, that will run the tests, so we can find out if something breaks at some point. 