### PR TITLE
Use pkg-config to find preCICE

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,7 @@ Before installing the adapter SU2 itself must be downloaded from https://github.
 It is assumed that preCICE has been installed successfully beforehand. Concerning installation instructions for preCICE, have a look at the preCICE-wiki pages on GitHub: https://github.com/precice/precice/wiki/Building.
 
 ### Adapter
-In order to run SU2 with the preCICE adapter, some SU2-native solver routines need to be changed. The altered SU2 files are provided with this adapter in the directory "replacement_files". Moreover, preCICE-specific files are contained in the directory "adapter_files". These need to be added to the source code of SU2. A simple shell script called *su2AdapterInstall* comes with the adapter, which automates this process and replaces/copies the adapted and preCICE-specific files to the correct locations within the SU2 package including the appropriately adjusted *Makefile* of SU2. For the script to work correctly, two environment variables need to be set prior to executing it:
-
-1. `PRECICE_ROOT`: Location of preCICE (top-level directory)
-2. `SU2_HOME`: Location of SU2 (top-level directory)
+In order to run SU2 with the preCICE adapter, some SU2-native solver routines need to be changed. The altered SU2 files are provided with this adapter in the directory "replacement_files". Moreover, preCICE-specific files are contained in the directory "adapter_files". These need to be added to the source code of SU2. A simple shell script called *su2AdapterInstall* comes with the adapter, which automates this process and replaces/copies the adapted and preCICE-specific files to the correct locations within the SU2 package including the appropriately adjusted *Makefile* of SU2. For the script to work correctly, the environment variable `SU2_HOME` needs to be set to the location of SU2 (top-level directory).
 
 It is recommended to set these variables permanently in your ~/.bashrc (Linux) or ~/.bash_profile (Mac). After setting these variables the script *su2AdapterInstall* can be run from the directory, in which it is contained:
 
@@ -50,15 +47,7 @@ If you do not want to use this script, manually copy the files to the locations 
 
 After copying the adapter files to the correct locations within the SU2 package, SU2 can be configured and built just like the original version of the solver suite. Please refer to the installation instructions provided with the SU2 source code. SU2 should be built with MPI support in order to make use of parallel functionalities. The script *su2AdapterInstall* states recommended command sequences for both the configuration and the building process upon completion of the execution.
 
-The SU2 executable is linked against the **dynamic library** of preCICE, so make sure you have built it like this. In order for the executable to find the library at runtime, the dynamic linker search path needs to be adapted manually. The easiest way is to copy the following line into ~/.bashrc (Linux).
-```
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PRECICE_ROOT/build/last"
-```
-For Mac-users the respective line, which needs to be added to ~/.bash_profile, is:
-```
-export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PRECICE_ROOT/build/last"
-```
-Alternatively, the correct dynamic linker search path can also be defined just for the SU2 executable (and not in ~/.bashrc or ~/.bash_profile).
+The SU2 executable is linked against the **dynamic library** of preCICE, so make sure you have built it like this.
 
 ## Running Simulations
 

--- a/adapter_files/precice.hpp
+++ b/adapter_files/precice.hpp
@@ -6,7 +6,7 @@
 
 
 
-#include "SolverInterface.hpp"
+#include "precice/SolverInterface.hpp"
 #include "SU2_CFD.hpp"
 #include <string>
 #include <stdlib.h>

--- a/replacement_files/Makefile.am
+++ b/replacement_files/Makefile.am
@@ -153,11 +153,15 @@ su2_cfd_sources = \
   ../include/SU2_CFD.hpp \
   ../src/SU2_CFD.cpp
 
-libSU2Core_cxx_flags = -I$(PRECICE_ROOT)/src/precice -fPIC
+libSU2Core_cxx_flags = -fPIC
 libSU2Core_libadd =
 
 su2_cfd_cxx_flags =
-su2_cfd_ldadd = -L$(PRECICE_ROOT)/build/last -lprecice
+su2_cfd_ldadd =
+
+# get preCICE CFLAGS and LIBS from pkg-config
+libSU2Core_cxx_flags += @preCICE_CFLAGS@
+su2_cfd_ldadd += @preCICE_LIBS@
 
 # always link to built dependencies from ./externals
 su2_cfd_cxx_flags += @su2_externals_INCLUDES@

--- a/replacement_files/configure.ac
+++ b/replacement_files/configure.ac
@@ -84,6 +84,7 @@ AS_IF([test -z "$PYTHON_INCLUDE"], [
 ])
 
 #PKG_PROG_PKG_CONFIG
+PKG_CHECK_MODULES(preCICE, libprecice)
 
 # --------------------------------------------------------------
 # Check for important type sizes

--- a/su2AdapterInstall
+++ b/su2AdapterInstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This auxiliary script simplifies the installation of the preCICE-adapter for SU2. It copies the adapted SU2-files to the correct locations based on the environment variables PRECICE_ROOT and SU2_HOME.
+# This auxiliary script simplifies the installation of the preCICE-adapter for SU2. It copies the adapted SU2-files to the correct locations based on the environment variable SU2_HOME.
 # Author: Alexander Rusch
 # SU2 version: 6.0.0 "Falcon"
 
@@ -12,7 +12,6 @@ cd "$(dirname "$0")"
 
 # Check for environment variables
 printf "\nChecking whether the necessary environment variables are set...\n"
-"${PRECICE_ROOT:?You need to set variable PRECICE_ROOT non-empty. Aborting.}"
 "${SU2_HOME:?You need to set variable SU2_HOME non-empty. Aborting.}"
 printf "Necessary environment variables are set.\n"
 
@@ -85,18 +84,5 @@ fi
 # Sample commands for configuring and making SU2
 printf "A sample SU2 configure procedure might look like: ./configure --prefix=\$SU2_HOME --enable-mpi\n"
 printf "A sample SU2 make procedure might look like: make -j 4\n\n"
-
-# Tell the user to adapt dynamic linker search path for preCICE depending on OS
-unamestr=`uname -s`
-if [[ "$unamestr" == 'Linux' ]]; then
-   printf "Please add the following line to your ~/.bashrc (for more information refer to the adapter README).\n"
-   printf "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:\$PRECICE_ROOT/build/last\"\n\n"
-elif [[ "$unamestr" == 'Darwin' ]]; then
-   printf "Please add the following line to your ~/.bash_profile (for more information refer to the adapter README).\n"
-   printf "export DYLD_LIBRARY_PATH=\"\$DYLD_LIBRARY_PATH:\$PRECICE_ROOT/build/last\"\n\n"
-else
-# Script was designed for Linux and macOS; other OS might work but this is not certain
-   printf "This script may not have executed properly on your system.\n\n"
-fi
 
 printf "Adapter installation completed. Make sure to follow the instructions above to build the adapted SU2.\n\n"


### PR DESCRIPTION
This removes the need for setting the `LD_LIBRARY_PATH`, `CPLUS_INCLUDE_PATH`, and `PRECICE_ROOT` environment variables and makes preCICE discoverable by pkg-config, which is the recommended method since preCICE v1.4.0.

The essential steps are also described in the page [Linking to preCICE (section Autotools)](https://github.com/precice/precice/wiki/Linking-to-preCICE#linking-from-autotools).

This breaks the out-of-the-box compatibility with SCons and the user is referred to this PR in case she
wants to keep using preCICE build with SCons.

@arusch @shkodm could you please check if this works in your setups?