### PR TITLE
Forbid solver-steered exit when preCICE is active, close #24

### DIFF
--- a/replacement_files/driver_structure.cpp
+++ b/replacement_files/driver_structure.cpp
@@ -3400,7 +3400,7 @@ void CDriver::StartSolver() {
     cout << endl << "------------------------------ Begin Solver -----------------------------" << endl;
 
   // preCICE
-  while ((ExtIter < config_container[ZONE_0]->GetnExtIter() && precice_usage && precice->isCouplingOngoing()) ||
+  while ((precice_usage && precice->isCouplingOngoing()) ||
          (ExtIter < config_container[ZONE_0]->GetnExtIter() && !precice_usage)) {
     // preCICE implicit coupling: saveOldState()
     if (precice_usage && precice->isActionRequired(precice->getCowic())) {
@@ -3464,8 +3464,8 @@ void CDriver::StartSolver() {
     Output(ExtIter, suppress_output_by_preCICE);
 
     /*--- If the convergence criteria has been met, terminate the simulation. ---*/
-
-    if (StopCalc) break;
+    
+    if (!precice_usage && StopCalc) break;
 
     ExtIter++;
   }


### PR DESCRIPTION
The max time is basically ignored when preCICE is active. I think this is the best compromise for now. Fixes #24 