### PR TITLE
Port SU2 adapter to preCICE v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The SU2 adapter now leverages the SU2 Python wrapper and preCICE Python bindings
 
 This adapter has been designed to work when using the compressible solver for unsteady problems with dual-time stepping, for single-zone problems. Implicit coupling currently saves the flow solution, turbulence solution, and the mesh solution (for mesh deformation). Species transport and transition model variables at this time are not saved, but may be straightforward to implement.
 
-**Note:** In its current state, the SU2 adapter is using the Python wrapper of SU2. The [previous implementation](https://github.com/precice/su2-adapter/tree/ab843878c1d43302a4f0c66e25dcb364b7787478) was directly editing the C++ source files of SU2. There is also a [version relying on the Python wrapper that however works with preCICE v2](https://github.com/precice/su2-adapter/tree/6540312608ed1c7e7b690fc48a51ebb3158b4b0c).
+**Note:** In its current state, the SU2 adapter is using the Python wrapper of SU2. The [previous implementation](https://github.com/precice/su2-adapter/tree/ab843878c1d43302a4f0c66e25dcb364b7787478) was directly editing the C++ source files of SU2. There is also a [version relying on the Python wrapper that however works with preCICE v2](https://github.com/precice/su2-adapter/commit/a87a1ed57e14dca97f1e47aab44632a254714004).
 
 <!-- tocstop -->
 ## Building the adapter

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ The SU2 adapter now leverages the SU2 Python wrapper and preCICE Python bindings
 
 This adapter has been designed to work when using the compressible solver for unsteady problems with dual-time stepping, for single-zone problems. Implicit coupling currently saves the flow solution, turbulence solution, and the mesh solution (for mesh deformation). Species transport and transition model variables at this time are not saved, but may be straightforward to implement.
 
-**Note:** In its current state, the SU2 adapter is using the Python wrapper of SU2. The [previous implementation](https://github.com/precice/su2-adapter/tree/ab843878c1d43302a4f0c66e25dcb364b7787478) was directly editing the C++ source files of SU2.
+**Note:** In its current state, the SU2 adapter is using the Python wrapper of SU2. The [previous implementation](https://github.com/precice/su2-adapter/tree/ab843878c1d43302a4f0c66e25dcb364b7787478) was directly editing the C++ source files of SU2. There is also a [version relying on the Python wrapper that however works with preCICE v2](https://github.com/precice/su2-adapter/tree/6540312608ed1c7e7b690fc48a51ebb3158b4b0c).
 
 <!-- tocstop -->
 ## Building the adapter
 
-The adapter depends on [SU2](https://su2code.github.io/), [preCICE v2](https://precice.org/installation-overview.html), and the [preCICE Python bindings](https://precice.org/installation-bindings-python.html).
+The adapter depends on [SU2](https://su2code.github.io/), [preCICE v3](https://precice.org/installation-overview.html), and the [preCICE Python bindings](https://precice.org/installation-bindings-python.html).
 
 The script `su2AdapterInstall` replaces a few files in the SU2 source code. You then need to build SU2 from source, install it into a prefix (`SU2_RUN`) and add that to your `PATH`.
 

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -182,10 +182,9 @@ def main():
   deltaT = min(precice_deltaT, deltaT)
 
   # Sleep briefly to allow for data initialization to be processed
-  # This should not be needed, but open an issue if it is:
-  # https://github.com/precice/su2-adapter/issues
+  # This should only be needed on some systems and use cases
   #
-  # sleep(3)
+  sleep(3)
 
   # Time loop is defined in Python so that we have access to SU2 functionalities at each time step
   if rank == 0:

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -176,11 +176,6 @@ def main():
   # Initialize preCICE
   participant.initialize()
 
-  # Setup time step sizes:
-  precice_deltaT = participant.get_max_time_step_size()
-  deltaT = SU2Driver.GetUnsteady_TimeStep()
-  deltaT = min(precice_deltaT, deltaT)
-
   # Sleep briefly to allow for data initialization to be processed
   # This should only be needed on some systems and use cases
   #
@@ -195,11 +190,13 @@ def main():
 
 
   while (participant.is_coupling_ongoing()):
-
     # Implicit coupling
     if (participant.requires_writing_checkpoint()):
       # Save the state
       SU2Driver.SaveOldState()
+
+    # Get the maximum time step size allowed by preCICE
+    precice_deltaT = participant.get_max_time_step_size()
 
     # Retrieve data from preCICE
     read_data = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT) 
@@ -244,7 +241,6 @@ def main():
 
     # Advance preCICE
     participant.advance(deltaT)
-    precice_deltaT = participant.get_max_time_step_size()
 
     # Implicit coupling:
     if (participant.requires_reading_checkpoint()):

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -182,7 +182,10 @@ def main():
   deltaT = min(precice_deltaT, deltaT)
 
   # Sleep briefly to allow for data initialization to be processed
-  sleep(3)
+  # This should not be needed, but open an issue if it is:
+  # https://github.com/precice/su2-adapter/issues
+  #
+  # sleep(3)
 
   # Time loop is defined in Python so that we have access to SU2 functionalities at each time step
   if rank == 0:

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -57,7 +57,7 @@ def main():
   parser.add_option("-r", "--precice-reverse", action="store_true", dest="precice_reverse", help="Include flag to have SU2 write temperature, read heat flux", default=False)
   
   # Dimension
-  parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain", type="int", default=3)
+  parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain", type="int", default=2)
   
   (options, args) = parser.parse_args()
   options.nZone = int(1) # Specify number of zones here (1)

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -84,16 +84,17 @@ def main():
   # Configure preCICE:
   size = comm.Get_size()
   try:
-    interface = precice.Interface(options.precice_name, options.precice_config, rank, size)
+    participant = precice.Participant(options.precice_name, options.precice_config, rank, size)
   except:
     print("There was an error configuring preCICE")
     return
   
+  mesh_name = options.precice_mesh
+
   # Check preCICE + SU2 dimensions
-  if options.nDim != interface.get_dimensions():
+  if options.nDim != participant.get_mesh_dimensions(mesh_name):
     print("SU2 and preCICE dimensions are not the same! Exiting")
     return
-
 
   CHTMarkerID = None
   CHTMarker = 'interface' # Name of CHT marker to couple
@@ -126,13 +127,6 @@ def main():
       if not SU2Driver.IsAHaloNode(CHTMarkerID, iVertex):
         iVertices_CHTMarker_PHYS.append(int(iVertex))
 
-  # Get preCICE mesh ID
-  try:
-    mesh_id = interface.get_mesh_id(options.precice_mesh)
-  except:
-    print("Invalid or no preCICE mesh name provided")
-    return
-
   # Get coords of vertices
   coords = numpy.zeros((nVertex_CHTMarker_PHYS, options.nDim))
   for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
@@ -141,7 +135,11 @@ def main():
       coords[i, iDim] = coord_passive[iDim]
 
   # Set mesh vertices in preCICE:
-  vertex_ids = interface.set_mesh_vertices(mesh_id, coords)
+  try:
+    vertex_ids = participant.set_mesh_vertices(mesh_name, coords)
+  except:
+    print("Could not set mesh vertices for preCICE. Was a (known) mesh specified in the options?")
+    return
 
   # Get read and write data IDs
   precice_read = "Temperature"
@@ -157,9 +155,6 @@ def main():
     SetFxn = SU2Driver.SetVertexNormalHeatFlux
     GetInitialFxn = SU2Driver.GetVertexNormalHeatFlux
 
-  read_data_id = interface.get_data_id(precice_read, mesh_id)
-  write_data_id = interface.get_data_id(precice_write, mesh_id)
-
   # Instantiate arrays to hold temperature + heat flux info
   read_data = numpy.zeros(nVertex_CHTMarker_PHYS)
   write_data = numpy.zeros(nVertex_CHTMarker_PHYS)
@@ -170,19 +165,24 @@ def main():
   nTimeIter = SU2Driver.GetnTimeIter()
   time = TimeIter*deltaT
 
-  # Setup preCICE dt:
-  precice_deltaT = interface.initialize()
-
   # Set up initial data for preCICE
-  if (interface.is_action_required(precice.action_write_initial_data())):
+  if (participant.requires_initial_data()):
 
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
       read_data[i] = GetInitialFxn(CHTMarkerID, iVertex)
 
-    interface.write_block_scalar_data(write_data_id, vertex_ids, read_data)
-    interface.mark_action_fulfilled(precice.action_write_initial_data())
+    participant.write_data(mesh_name, precice_write, vertex_ids, read_data)
 
-  interface.initialize_data()
+  # Initialize preCICE
+  participant.initialize()
+
+  # Setup time step sizes:
+  precice_deltaT = participant.get_max_time_step_size()
+  deltaT = SU2Driver.GetUnsteady_TimeStep()
+  print("====================================")
+  print(precice_deltaT)
+  print(deltaT)
+  deltaT = min(precice_deltaT, deltaT)
 
   # Sleep briefly to allow for data initialization to be processed
   sleep(3)
@@ -195,30 +195,29 @@ def main():
     comm.Barrier()
 
 
-  while (interface.is_coupling_ongoing()):
+  while (participant.is_coupling_ongoing()):
 
     # Implicit coupling
-    if (interface.is_action_required(precice.action_write_iteration_checkpoint())):
+    if (participant.requires_writing_checkpoint()):
       # Save the state
       SU2Driver.SaveOldState()
-      interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
 
-    if (interface.is_read_data_available()):
-      # Retrieve data from preCICE
-      read_data = interface.read_block_scalar_data(read_data_id, vertex_ids) 
+    # Retrieve data from preCICE
+    read_data = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT) 
 
-      # Set the updated values
-      for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
-          SetFxn(CHTMarkerID, iVertex, read_data[i])
+    # Set the updated values
+    for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
+        SetFxn(CHTMarkerID, iVertex, read_data[i])
 
-      # Tell the SU2 drive to update the boundary conditions
-      SU2Driver.BoundaryConditionsUpdate()
+    # Tell the SU2 drive to update the boundary conditions
+    SU2Driver.BoundaryConditionsUpdate()
 
     if options.with_MPI == True:
       comm.Barrier()
 
     # Update timestep based on preCICE
     deltaT = SU2Driver.GetUnsteady_TimeStep()
+    precice_deltaT = participant.get_max_time_step_size()
     deltaT = min(precice_deltaT, deltaT)
     SU2Driver.SetUnsteady_TimeStep(deltaT)
 
@@ -237,23 +236,22 @@ def main():
     # Monitor the solver and output solution to file if required
     stopCalc = SU2Driver.Monitor(TimeIter)
     
-    if (interface.is_write_data_required(deltaT)):
-      # Loop over the vertices
-      for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
-        # Get heat fluxes at each vertex
-        write_data[i] = GetFxn(CHTMarkerID, iVertex)
-        
-      # Write data to preCICE
-      interface.write_block_scalar_data(write_data_id, vertex_ids, write_data)
+    # Loop over the vertices
+    for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
+      # Get heat fluxes at each vertex
+      write_data[i] = GetFxn(CHTMarkerID, iVertex)
+      
+    # Write data to preCICE
+    participant.write_data(mesh_name, precice_write, vertex_ids, write_data)
 
     # Advance preCICE
-    precice_deltaT = interface.advance(deltaT)
+    participant.advance(deltaT)
+    precice_deltaT = participant.get_max_time_step_size()
 
     # Implicit coupling:
-    if (interface.is_action_required(precice.action_read_iteration_checkpoint())):
+    if (participant.requires_reading_checkpoint()):
       # Reload old state
       SU2Driver.ReloadOldState()
-      interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
     else: # Output and increment as usual
       SU2Driver.Output(TimeIter)
       if (stopCalc == True):
@@ -269,7 +267,7 @@ def main():
   # Postprocess the solver and exit cleanly
   SU2Driver.Postprocessing()
   
-  interface.finalize()
+  participant.finalize()
   
   if SU2Driver != None:
     del SU2Driver

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -57,7 +57,7 @@ def main():
   parser.add_option("-r", "--precice-reverse", action="store_true", dest="precice_reverse", help="Include flag to have SU2 write temperature, read heat flux", default=False)
   
   # Dimension
-  parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain", type="int", default=2)
+  parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain (2D/3D)", type="int", default=2)
   
   (options, args) = parser.parse_args()
   options.nZone = int(1) # Specify number of zones here (1)

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -179,9 +179,6 @@ def main():
   # Setup time step sizes:
   precice_deltaT = participant.get_max_time_step_size()
   deltaT = SU2Driver.GetUnsteady_TimeStep()
-  print("====================================")
-  print(precice_deltaT)
-  print(deltaT)
   deltaT = min(precice_deltaT, deltaT)
 
   # Sleep briefly to allow for data initialization to be processed
@@ -217,7 +214,6 @@ def main():
 
     # Update timestep based on preCICE
     deltaT = SU2Driver.GetUnsteady_TimeStep()
-    precice_deltaT = participant.get_max_time_step_size()
     deltaT = min(precice_deltaT, deltaT)
     SU2Driver.SetUnsteady_TimeStep(deltaT)
 

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -56,7 +56,7 @@ def main():
     parser.add_option("-m", "--precice-mesh", dest="precice_mesh", help="Specify the preCICE mesh name", default="Fluid-Mesh")
 
     # Dimension
-    parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain", type="int", default=2)
+    parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain (2D/3D)", type="int", default=2)
   
     (options, args) = parser.parse_args()
     options.nZone = int(1)

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -56,7 +56,7 @@ def main():
     parser.add_option("-m", "--precice-mesh", dest="precice_mesh", help="Specify the preCICE mesh name", default="Fluid-Mesh")
 
     # Dimension
-    parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain", type="int", default=3)
+    parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain", type="int", default=2)
   
     (options, args) = parser.parse_args()
     options.nZone = int(1)

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -173,7 +173,10 @@ def main():
     deltaT = min(precice_deltaT, deltaT)
 
     # Sleep briefly to allow for data initialization to be processed
-    sleep(3)
+    # This should not be needed, but open an issue if it is:
+    # https://github.com/precice/su2-adapter/issues
+    #
+    # sleep(3)
 
     # Time loop is defined in Python so that we have acces to SU2 functionalities at each time step
     if rank == 0:

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -167,11 +167,6 @@ def main():
     # Initialize preCICE
     participant.initialize()
 
-    # Setup time step sizes:
-    precice_deltaT = participant.get_max_time_step_size()
-    deltaT = SU2Driver.GetUnsteady_TimeStep()
-    deltaT = min(precice_deltaT, deltaT)
-
     # Sleep briefly to allow for data initialization to be processed
     # This should only be needed on some systems and use cases
     #
@@ -190,6 +185,9 @@ def main():
         if (participant.requires_writing_checkpoint()):
             # Save the state
             SU2Driver.SaveOldState()
+
+        # Get the maximum time step size allowed by preCICE
+        precice_deltaT = participant.get_max_time_step_size()
 
         # Retreive data from preCICE
         displacements = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT)
@@ -236,8 +234,6 @@ def main():
 
         # Advance preCICE
         participant.advance(deltaT)
-        precice_deltaT = participant.get_max_time_step_size()
-
 
         # Implicit coupling:
         if (participant.requires_reading_checkpoint()):

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -173,10 +173,9 @@ def main():
     deltaT = min(precice_deltaT, deltaT)
 
     # Sleep briefly to allow for data initialization to be processed
-    # This should not be needed, but open an issue if it is:
-    # https://github.com/precice/su2-adapter/issues
+    # This should only be needed on some systems and use cases
     #
-    # sleep(3)
+    sleep(3)
 
     # Time loop is defined in Python so that we have acces to SU2 functionalities at each time step
     if rank == 0:


### PR DESCRIPTION
Building upon #32.
The adapter includes two example Python scripts, which work with the tutorials from https://github.com/precice/tutorials/pull/324 (already ported to v3).

@IshaanDesai could you please compare to the [porting guide](https://precice.org/couple-your-code-porting-v2-3.html) or other Python-based adapters? Should be very quick for you to spot any misuses of the Python bindings.

@BenjaminRodenberg could you please have a quick look regarding the time stepping? Are we updating all time step sizes at the right point?

@j-signorelli this is probably interesting for you as well, as you can now directly use preCICE v3! :tada: In case you open any follow-up PR, I can take care of the conflicts.

No need to run/test anything, I have checked that the tutorial runs, and the results look reasonable (I have not done any detailed comparison, but I would not expect any potential changes to be related to this porting).