### PR TITLE
Simplify checkpointing and output

### DIFF
--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -55,10 +55,10 @@ def main():
   parser.add_option("-c", "--precice-config", dest="precice_config", help="Specify preCICE config file", default="../precice-config.xml")
   parser.add_option("-m", "--precice-mesh", dest="precice_mesh", help="Specify the preCICE mesh name", default="Fluid-Mesh")
   parser.add_option("-r", "--precice-reverse", action="store_true", dest="precice_reverse", help="Include flag to have SU2 write temperature, read heat flux", default=False)
-
+  
   # Dimension
   parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain (2D/3D)", type="int", default=2)
-
+  
   (options, args) = parser.parse_args()
   options.nZone = int(1) # Specify number of zones here (1)
 
@@ -90,7 +90,7 @@ def main():
   except:
     print("There was an error configuring preCICE")
     return
-
+  
   mesh_name = options.precice_mesh
 
   # Check preCICE + SU2 dimensions
@@ -110,7 +110,7 @@ def main():
   #Check if the specified marker has a CHT option and if it exists on this rank.
   if CHTMarker in CHTMarkerList and CHTMarker in allMarkerIDs.keys():
     CHTMarkerID = allMarkerIDs[CHTMarker] # So: if CHTMarkerID != None, then it exists on this rank
-
+  
   # Number of vertices on the specified marker (per rank)
   nVertex_CHTMarker = 0         #total number of vertices (physical + halo) on this rank
   nVertex_CHTMarker_HALO = 0    #number of halo vertices
@@ -204,7 +204,7 @@ def main():
     precice_deltaT = participant.get_max_time_step_size()
 
     # Retrieve data from preCICE
-    read_data = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT)
+    read_data = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT) 
 
     # Set the updated values
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
@@ -232,19 +232,15 @@ def main():
 
     # Update the solver for the next time iteration
     SU2Driver.Update()
-
+    
     # Monitor the solver
     stopCalc = SU2Driver.Monitor(TimeIter)
-
-    # Update control parameters
-    TimeIter += 1
-    time += deltaT
-
+    
     # Loop over the vertices
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
       # Get heat fluxes at each vertex
       write_data[i] = GetFxn(CHTMarkerID, iVertex)
-
+      
     # Write data to preCICE
     participant.write_data(mesh_name, precice_write, vertex_ids, write_data)
 
@@ -266,12 +262,12 @@ def main():
 
     if options.with_MPI == True:
       comm.Barrier()
-
+      
   # Postprocess the solver and exit cleanly
   SU2Driver.Postprocessing()
-
+  
   participant.finalize()
-
+  
   if SU2Driver != None:
     del SU2Driver
 

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -235,7 +235,11 @@ def main():
     
     # Monitor the solver
     stopCalc = SU2Driver.Monitor(TimeIter)
-    
+
+    # Update control parameters
+    TimeIter += 1
+    time += deltaT
+
     # Loop over the vertices
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
       # Get heat fluxes at each vertex
@@ -247,9 +251,6 @@ def main():
     # Advance preCICE
     participant.advance(deltaT)
 
-    if (stopCalc == True):
-      break
-
     # Implicit coupling:
     if (participant.requires_reading_checkpoint()):
       # Reload old state
@@ -259,6 +260,8 @@ def main():
 
     if (participant.is_time_window_complete()):
       SU2Driver.Output(TimeIter)
+      if (stopCalc == True):
+        break
 
     if options.with_MPI == True:
       comm.Barrier()

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -55,10 +55,10 @@ def main():
   parser.add_option("-c", "--precice-config", dest="precice_config", help="Specify preCICE config file", default="../precice-config.xml")
   parser.add_option("-m", "--precice-mesh", dest="precice_mesh", help="Specify the preCICE mesh name", default="Fluid-Mesh")
   parser.add_option("-r", "--precice-reverse", action="store_true", dest="precice_reverse", help="Include flag to have SU2 write temperature, read heat flux", default=False)
-  
+
   # Dimension
   parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain (2D/3D)", type="int", default=2)
-  
+
   (options, args) = parser.parse_args()
   options.nZone = int(1) # Specify number of zones here (1)
 
@@ -90,7 +90,7 @@ def main():
   except:
     print("There was an error configuring preCICE")
     return
-  
+
   mesh_name = options.precice_mesh
 
   # Check preCICE + SU2 dimensions
@@ -110,7 +110,7 @@ def main():
   #Check if the specified marker has a CHT option and if it exists on this rank.
   if CHTMarker in CHTMarkerList and CHTMarker in allMarkerIDs.keys():
     CHTMarkerID = allMarkerIDs[CHTMarker] # So: if CHTMarkerID != None, then it exists on this rank
-  
+
   # Number of vertices on the specified marker (per rank)
   nVertex_CHTMarker = 0         #total number of vertices (physical + halo) on this rank
   nVertex_CHTMarker_HALO = 0    #number of halo vertices
@@ -204,7 +204,7 @@ def main():
     precice_deltaT = participant.get_max_time_step_size()
 
     # Retrieve data from preCICE
-    read_data = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT) 
+    read_data = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT)
 
     # Set the updated values
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
@@ -232,20 +232,27 @@ def main():
 
     # Update the solver for the next time iteration
     SU2Driver.Update()
-    
+
     # Monitor the solver
     stopCalc = SU2Driver.Monitor(TimeIter)
-    
+
+    # Update control parameters
+    TimeIter += 1
+    time += deltaT
+
     # Loop over the vertices
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
       # Get heat fluxes at each vertex
       write_data[i] = GetFxn(CHTMarkerID, iVertex)
-      
+
     # Write data to preCICE
     participant.write_data(mesh_name, precice_write, vertex_ids, write_data)
 
     # Advance preCICE
     participant.advance(deltaT)
+
+    if (stopCalc == True):
+      break
 
     # Implicit coupling:
     if (participant.requires_reading_checkpoint()):
@@ -253,23 +260,18 @@ def main():
       SU2Driver.ReloadOldState()
       time = precice_saved_time
       TimeIter = precice_saved_iter
-    else: # Output and increment as usual
-      SU2Driver.Output(TimeIter)
-      if (stopCalc == True):
-        break
-      # Update control parameters
-      TimeIter += 1
-      time += deltaT
 
+    if (participant.is_time_window_complete()):
+      SU2Driver.Output(TimeIter)
 
     if options.with_MPI == True:
       comm.Barrier()
-      
+
   # Postprocess the solver and exit cleanly
   SU2Driver.Postprocessing()
-  
+
   participant.finalize()
-  
+
   if SU2Driver != None:
     del SU2Driver
 

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -244,9 +244,6 @@ def main():
         # Advance preCICE
         participant.advance(deltaT)
 
-        if (stopCalc == True):
-            break
-
         # Implicit coupling:
         if (participant.requires_reading_checkpoint()):
             # Reload old state
@@ -256,6 +253,8 @@ def main():
 
         if (participant.is_time_window_complete()):
             SU2Driver.Output(TimeIter)
+            if (stopCalc == True):
+                break
 
         if options.with_MPI == True:
             comm.Barrier()

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -57,7 +57,7 @@ def main():
 
     # Dimension
     parser.add_option("-d", "--dimension", dest="nDim", help="Dimension of fluid domain (2D/3D)", type="int", default=2)
-
+  
     (options, args) = parser.parse_args()
     options.nZone = int(1)
 
@@ -115,17 +115,17 @@ def main():
     nVertex_MovingMarker_PHYS = 0    #number of physical vertices
     iVertices_MovingMarker_PHYS = [] # indices of vertices this rank is working on
     # Datatypes must be primitive as input to SU2 wrapper code, not numpy.int8, numpy.int64, etc.. So a list is used
-
+    
     if MovingMarkerID != None:
         nVertex_MovingMarker = SU2Driver.GetNumberVertices(MovingMarkerID)
         nVertex_MovingMarker_HALO = SU2Driver.GetNumberHaloVertices(MovingMarkerID)
         nVertex_MovingMarker_PHYS = nVertex_MovingMarker - nVertex_MovingMarker_HALO
-
+        
         # Obtain indices of all vertices that are being worked on on this rank
         for iVertex in range(nVertex_MovingMarker):
             if not SU2Driver.IsAHaloNode(MovingMarkerID, iVertex):
                 iVertices_MovingMarker_PHYS.append(int(iVertex))
-
+    
     # Get coords of vertices
     coords = numpy.zeros((nVertex_MovingMarker_PHYS, options.nDim))
     for i, iVertex in enumerate(iVertices_MovingMarker_PHYS):
@@ -184,7 +184,7 @@ def main():
     precice_saved_time = 0
     precice_saved_iter = 0
     while (participant.is_coupling_ongoing()):#(TimeIter < nTimeIter):
-
+        
         # Implicit coupling
         if (participant.requires_writing_checkpoint()):
             # Save the state
@@ -197,7 +197,7 @@ def main():
 
         # Retreive data from preCICE
         displacements = participant.read_data(mesh_name, precice_read, vertex_ids, deltaT)
-
+        
         # Set the updated displacements
         for i, iVertex in enumerate(iVertices_MovingMarker_PHYS):
             DisplX = displacements[i][0]
@@ -205,15 +205,15 @@ def main():
             DisplZ = 0 if options.nDim == 2 else displacements[i][2]
 
             SU2Driver.SetMeshDisplacement(MovingMarkerID, iVertex, DisplX, DisplY, DisplZ)
-
+        
         if options.with_MPI == True:
             comm.Barrier()
-
+            
         # Update timestep based on preCICE
         deltaT = SU2Driver.GetUnsteady_TimeStep()
         deltaT = min(precice_deltaT, deltaT)
         SU2Driver.SetUnsteady_TimeStep(deltaT)
-
+        
         # Time iteration preprocessing (mesh is deformed here)
         SU2Driver.Preprocess(TimeIter)
 


### PR DESCRIPTION
Follow up PR to #33 

* Simplifies how internal time and counter are updated (I think this should directly happen after the time step is completed)
* Only output `if (participant.is_time_window_complete())`. Otherwise there is the risk of outputting non-converged results, if we are subcycling.