### PR TITLE
Update license headers and target SU2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SU2-preCICE adapter
 
-This is a [preCICE](https://precice.org/) adapter for [SU2](https://su2code.github.io/) versions 7.5.0 and 7.5.1 "Blackbird",
+This is a [preCICE](https://precice.org/) adapter for [SU2](https://su2code.github.io/) version 7.5.1 "Blackbird",
 including examples for conjugate heat transfer and fluid-structure interation simulations.
 
 Read more in the [documentation](https://precice.org/adapter-su2-overview.html).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,7 +6,7 @@ keywords: adapter, su2, development, modules
 summary: "Modify native SU2 files to couple with other solvers or SU2 itself"
 ---
 
-The [SU2 adapter](https://github.com/precice/su2-adapter) leverages the SU2 Python wrapper and preCICE Python bindings to couple SU2 using preCICE in a minimally invasive way. The adapter simply updates existing functions and implements new ones in the SU2 Python wrapper that allow for simple preCICE implementation with implicit coupling. The adapter currently works for SU2 versions 7.5.0 and 7.5.1 "Blackbird".
+The [SU2 adapter](https://github.com/precice/su2-adapter) leverages the SU2 Python wrapper and preCICE Python bindings to couple SU2 using preCICE in a minimally invasive way. The adapter simply updates existing functions and implements new ones in the SU2 Python wrapper that allow for simple preCICE implementation with implicit coupling. The adapter currently works for SU2 version 7.5.1 "Blackbird".
 
 The adapter can simulate the flow domain in both conjugate heat-transfer and fluid-structure interaction applications. It supports:
 

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -1,41 +1,23 @@
 #!/usr/bin/env python3
 
-## File edited to work coupled with preCICE - Joseph Signorelli
-
-## \file launch_unsteady_CHT_FlatPlate.py
-#  \brief Python script to launch SU2_CFD with customized unsteady boundary conditions using the Python wrapper.
-#  \author David Thomas
-#  \version 7.4.0 "Blackbird"
+## \file SU2_preCICE_CHT.py
+#  \brief Python script to launch SU2_CFD with preCICE for conjugate heat transfer simulations.
+#  \author Joseph Signorelli
+#  \version 7.5.1 "Blackbird"
 #
-# SU2 Project Website: https://su2code.github.io
-#
-# The SU2 Project is maintained by the SU2 Foundation
-# (http://su2foundation.org)
-#
-# Copyright 2012-2022, SU2 Contributors (cf. AUTHORS.md)
-#
-# SU2 is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
-#
-# SU2 is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with SU2. If not, see <http://www.gnu.org/licenses/>.
+# Part of the SU2-preCICE adapter: https://github.com/precice/su2-adapter
+# This adapter is distributed under the GNU Lesser General Public
+# License (see LICENSE file).
 
 # ----------------------------------------------------------------------
 #  Imports
 # ----------------------------------------------------------------------
 
 import sys
-from optparse import OptionParser	# use a parser for configuration
-import pysu2			            # imports the SU2 wrapped module
+from optparse import OptionParser # use a parser for configuration
+import pysu2                      # imports the SU2 wrapped module
 from math import *
-import precice #import precice
+import precice
 import numpy
 from time import sleep
 # -------------------------------------------------------------------

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -1,31 +1,13 @@
 #!/usr/bin/env python3
 
-## File edited to work coupled with preCICE - Joseph Signorelli
-
-## \file flatPlate_rigidMotion.py
-#  \brief Python script to launch SU2_CFD with customized unsteady boundary conditions using the Python wrapper.
-#  \author David Thomas
-#  \version 7.5.0 "Blackbird"
+## \file SU2_preCICE_FSI.py
+#  \brief Python script to launch SU2_CFD with preCICE for fluid-structure interation simulations.
+#  \author Joseph Signorelli
+#  \version 7.5.1 "Blackbird"
 #
-# SU2 Project Website: https://su2code.github.io
-#
-# The SU2 Project is maintained by the SU2 Foundation
-# (http://su2foundation.org)
-#
-# Copyright 2012-2022, SU2 Contributors (cf. AUTHORS.md)
-#
-# SU2 is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
-#
-# SU2 is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with SU2. If not, see <http://www.gnu.org/licenses/>.
+# Part of the SU2-preCICE adapter: https://github.com/precice/su2-adapter
+# This adapter is distributed under the GNU Lesser General Public
+# License (see LICENSE file).
 
 # ----------------------------------------------------------------------
 #  Imports


### PR DESCRIPTION
Following @uekerman's suggestion and @j-signorelli's feedback in https://github.com/precice/su2-adapter/pull/35#discussion_r1551304212, this PR:

- Specifies only SU2 7.5.1 as version. It should also work with 7.5.0, but let's only specify the latest one that we know works. The installation script still checks for both 7.5.0 and 7.5.1.
- Updates the file headers (description/license/copyright) of the two Python scripts, specifying @j-signorelli as author, clarifying that the license of the adapter is GPL, and updating the versions. The link to the SU2 project should already be clear in multiple points, including the README.

I compared with the files that were used as starting point, and I don't think there is enough similarity to justify a full citation. It seems to me like we are distributing two scripts based on the general framework that the SU2 Python wrapper provides. I am very happy to apply a better practice if pointed to one.

- CHT script: https://github.com/su2code/SU2/blob/v7.5.1/TestCases/py_wrapper/flatPlate_unsteady_CHT/launch_unsteady_CHT_FlatPlate.py
- FSI script: https://github.com/su2code/SU2/blob/v7.5.1/TestCases/py_wrapper/flatPlate_rigidMotion/launch_flatPlate_rigidMotion.py

@uekerman @j-signorelli a short "looks good" would be very welcome here.