### PR TITLE
Fix heat flux write sign and CHT data initialization

### DIFF
--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -218,10 +218,6 @@ def main():
     # Monitor the solver
     stopCalc = SU2Driver.Monitor(TimeIter)
 
-    # Update control parameters
-    TimeIter += 1
-    time += deltaT
-
     # Loop over the vertices
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
       # Get heat fluxes at each vertex
@@ -244,6 +240,9 @@ def main():
       SU2Driver.Output(TimeIter)
       if (stopCalc == True):
         break
+      # Update control parameters
+      TimeIter += 1
+      time += deltaT
 
     if options.with_MPI == True:
       comm.Barrier()

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -130,14 +130,12 @@ def main():
   precice_write = "Heat-Flux"
   GetFxn = lambda *args: -1*SU2Driver.GetVertexNormalHeatFlux(*args)
   SetFxn = SU2Driver.SetVertexTemperature
-  GetInitialFxn = SU2Driver.GetVertexTemperature
   # Reverse coupling data read/write if -r flag included
   if options.precice_reverse:
     precice_read = "Heat-Flux"
     precice_write = "Temperature"
     GetFxn = SU2Driver.GetVertexTemperature
     SetFxn = SU2Driver.SetVertexNormalHeatFlux
-    GetInitialFxn = lambda *args: -1*SU2Driver.GetVertexNormalHeatFlux(*args)
 
   # Instantiate arrays to hold temperature + heat flux info
   read_data = numpy.zeros(nVertex_CHTMarker_PHYS)
@@ -153,7 +151,7 @@ def main():
   if (participant.requires_initial_data()):
 
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
-      write_data[i] = GetInitialFxn(CHTMarkerID, iVertex)
+      write_data[i] = GetFxn(CHTMarkerID, iVertex)
 
     participant.write_data(mesh_name, precice_write, vertex_ids, write_data)
 

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -128,7 +128,7 @@ def main():
   # Get read and write data IDs
   precice_read = "Temperature"
   precice_write = "Heat-Flux"
-  GetFxn = SU2Driver.GetVertexNormalHeatFlux
+  GetFxn = lambda *args: -1*SU2Driver.GetVertexNormalHeatFlux(*args)
   SetFxn = SU2Driver.SetVertexTemperature
   GetInitialFxn = SU2Driver.GetVertexTemperature
   # Reverse coupling data read/write if -r flag included
@@ -137,7 +137,7 @@ def main():
     precice_write = "Temperature"
     GetFxn = SU2Driver.GetVertexTemperature
     SetFxn = SU2Driver.SetVertexNormalHeatFlux
-    GetInitialFxn = SU2Driver.GetVertexNormalHeatFlux
+    GetInitialFxn = lambda *args: -1*SU2Driver.GetVertexNormalHeatFlux(*args)
 
   # Instantiate arrays to hold temperature + heat flux info
   read_data = numpy.zeros(nVertex_CHTMarker_PHYS)

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -216,6 +216,10 @@ def main():
     # Monitor the solver
     stopCalc = SU2Driver.Monitor(TimeIter)
 
+    # Update control parameters
+    TimeIter += 1
+    time += deltaT
+
     # Loop over the vertices
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
       # Get heat fluxes at each vertex
@@ -238,9 +242,6 @@ def main():
       SU2Driver.Output(TimeIter)
       if (stopCalc == True):
         break
-      # Update control parameters
-      TimeIter += 1
-      time += deltaT
 
     if options.with_MPI == True:
       comm.Barrier()

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -126,16 +126,17 @@ def main():
     return
 
   # Get read and write data IDs
-  precice_read = "Temperature"
-  precice_write = "Heat-Flux"
-  GetFxn = lambda *args: -1*SU2Driver.GetVertexNormalHeatFlux(*args)
-  SetFxn = SU2Driver.SetVertexTemperature
   # Reverse coupling data read/write if -r flag included
   if options.precice_reverse:
     precice_read = "Heat-Flux"
     precice_write = "Temperature"
     GetFxn = SU2Driver.GetVertexTemperature
     SetFxn = SU2Driver.SetVertexNormalHeatFlux
+  else:
+    precice_read = "Temperature"
+    precice_write = "Heat-Flux"
+    GetFxn = lambda *args: -1*SU2Driver.GetVertexNormalHeatFlux(*args)
+    SetFxn = SU2Driver.SetVertexTemperature
 
   # Instantiate arrays to hold temperature + heat flux info
   read_data = numpy.zeros(nVertex_CHTMarker_PHYS)

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -174,6 +174,13 @@ def main():
 
   precice_saved_time = 0
   precice_saved_iter = 0
+  
+  # Patch for su2code/SU2#2353
+  if (TimeIter == 0):
+    SU2Driver.Output(TimeIter)
+    TimeIter += 1
+    time += deltaT
+  
   while (participant.is_coupling_ongoing()):
     # Implicit coupling
     if (participant.requires_writing_checkpoint()):

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -125,14 +125,15 @@ def main():
     print("Could not set mesh vertices for preCICE. Was a (known) mesh specified in the options?")
     return
 
-  # Get read and write data IDs
-  # Reverse coupling data read/write if -r flag included
+  # Get read and write data
   if options.precice_reverse:
+    # Reverse coupling data read/write if -r flag included
     precice_read = "Heat-Flux"
     precice_write = "Temperature"
     GetFxn = SU2Driver.GetVertexTemperature
     SetFxn = SU2Driver.SetVertexNormalHeatFlux
   else:
+    # Default assumption: reading temperature, writing heat flux as going out of the fluid
     precice_read = "Temperature"
     precice_write = "Heat-Flux"
     GetFxn = lambda *args: -1*SU2Driver.GetVertexNormalHeatFlux(*args)

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -172,13 +172,6 @@ def main():
 
   precice_saved_time = 0
   precice_saved_iter = 0
-  
-  # Patch for su2code/SU2#2353
-  if (TimeIter == 0):
-    SU2Driver.Output(TimeIter)
-    TimeIter += 1
-    time += deltaT
-  
   while (participant.is_coupling_ongoing()):
     # Implicit coupling
     if (participant.requires_writing_checkpoint()):

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -211,10 +211,6 @@ def main():
         # Monitor the solver
         stopCalc = SU2Driver.Monitor(TimeIter)
 
-        # Update control parameters
-        TimeIter += 1
-        time += deltaT
-
         # Loop over the vertices
         for i, iVertex in enumerate(iVertices_MovingMarker_PHYS):
             # Get forces at each vertex
@@ -237,6 +233,9 @@ def main():
             SU2Driver.Output(TimeIter)
             if (stopCalc == True):
                 break
+            # Update control parameters
+            TimeIter += 1
+            time += deltaT
 
         if options.with_MPI == True:
             comm.Barrier()

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -165,6 +165,13 @@ def main():
 
     precice_saved_time = 0
     precice_saved_iter = 0
+
+    # Patch for su2code/SU2#2353
+    if (TimeIter == 0):
+        SU2Driver.Output(TimeIter)
+        TimeIter += 1
+        time += deltaT
+
     while (participant.is_coupling_ongoing()):#(TimeIter < nTimeIter):
         
         # Implicit coupling

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -211,6 +211,10 @@ def main():
         # Monitor the solver
         stopCalc = SU2Driver.Monitor(TimeIter)
 
+        # Update control parameters
+        TimeIter += 1
+        time += deltaT
+
         # Loop over the vertices
         for i, iVertex in enumerate(iVertices_MovingMarker_PHYS):
             # Get forces at each vertex
@@ -233,9 +237,6 @@ def main():
             SU2Driver.Output(TimeIter)
             if (stopCalc == True):
                 break
-            # Update control parameters
-            TimeIter += 1
-            time += deltaT
 
         if options.with_MPI == True:
             comm.Barrier()

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -165,13 +165,6 @@ def main():
 
     precice_saved_time = 0
     precice_saved_iter = 0
-
-    # Patch for su2code/SU2#2353
-    if (TimeIter == 0):
-        SU2Driver.Output(TimeIter)
-        TimeIter += 1
-        time += deltaT
-
     while (participant.is_coupling_ongoing()):#(TimeIter < nTimeIter):
         
         # Implicit coupling


### PR DESCRIPTION
Two issues are resolved here:

1. When the fluid sends heat flux / receives temperature, the heat flux sign was that of going _into_ of the fluid. It makes more sense that the adapter sends the heat flux going out of the fluid / into the solid. This PR multiples HF by -1 before sending it, to ensure that it reflects the normal heat flux going out of the fluid. This can be tested by running a CHT test case, such as flow-over-heated-plate, **without** using `-r` flag (and subsequently updating the fluid BC to be isothermal, solid to be heat-flux), where there is a fluid-Dirichlet/solid-Neumann coupling.

2. Data initialization for CHT is wrong. This PR fixes that.