### PR TITLE
Time iteration consistency + restart file documentation

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -105,7 +105,9 @@ mpirun -n 8 python3 SU2_preCICE_CHT.py -f SU2_config_file.cfg --parallel
 As of SU2 v7.5.1: Deforming `MARKER_EULER`'s are buggy when simulations are run in parallel, leading to unexpected results. More information can be found at [this SU2 discussion](https://github.com/su2code/SU2/discussions/1931).
 {% endnote %}
 
-## Important note on restarts
+## Important notes
+
+It is strongly recommended use a restart file like `restart_000000.dat` as an initial condition as opposed to default initialization. Because dual-timestepping is an implicit scheme, any time-dependent components should be evaluated at the $t_{n+1}$ state, and this is ensured by using a restart file as the initial condition. Otherwise, they are computed at $t_n$. See [su2code/SU2#2353](https://github.com/su2code/SU2/issues/2353) for more information. With this approach, an output file with iteration suffix $N$ represents the solution data at time $N\Delta t$ (ie: `restart_000010.dat` is the solution data at $t=10\Delta t)$.
 
 This code **has not been tested** for restarts using initializations *from* SU2. Any restarted simulations should have SU2 be the first participant and receive initialization data. It is possible that, if SU2 must send initialization data, that it is incorrect (it may use default values in the config file, or just be zeros if the data hasn't been computed until after/during a first iteration). Admittedly, this is from a lack of understanding of the specifics of how SU2 operates and there may not be a trivial work-around.
 

--- a/run/SU2_preCICE_CHT.py
+++ b/run/SU2_preCICE_CHT.py
@@ -218,10 +218,6 @@ def main():
     # Monitor the solver
     stopCalc = SU2Driver.Monitor(TimeIter)
 
-    # Update control parameters
-    TimeIter += 1
-    time += deltaT
-
     # Loop over the vertices
     for i, iVertex in enumerate(iVertices_CHTMarker_PHYS):
       # Get heat fluxes at each vertex
@@ -244,6 +240,9 @@ def main():
       SU2Driver.Output(TimeIter)
       if (stopCalc == True):
         break
+      # Update control parameters
+      TimeIter += 1
+      time += deltaT
 
     if options.with_MPI == True:
       comm.Barrier()

--- a/run/SU2_preCICE_FSI.py
+++ b/run/SU2_preCICE_FSI.py
@@ -211,10 +211,6 @@ def main():
         # Monitor the solver
         stopCalc = SU2Driver.Monitor(TimeIter)
 
-        # Update control parameters
-        TimeIter += 1
-        time += deltaT
-
         # Loop over the vertices
         for i, iVertex in enumerate(iVertices_MovingMarker_PHYS):
             # Get forces at each vertex
@@ -237,6 +233,9 @@ def main():
             SU2Driver.Output(TimeIter)
             if (stopCalc == True):
                 break
+            # Update control parameters
+            TimeIter += 1
+            time += deltaT
 
         if options.with_MPI == True:
             comm.Barrier()


### PR DESCRIPTION
- [X] In the SU2 source code and corresponding Python examples in TestCases, the `TimeIter` and `time` variables are updated after `Output` is called. This PR updates the run scripts to match that, as it was for the preCICE v2 version: #32.

- [X] Dual-timestepping (an implicit time scheme) should have any the time-varying source terms / BCs / etc.  computed at the `t+dt` state. When importing a restart file as an initial condition, `TimeIter` is initialized to 1, and `time` to `dt`. In general across SU2, all time-varying "things" are computed with the time `TimeIter*dt`. So, when importing a restart file, computations are performed with the time-varying "things" at the **correct** `t+dt` time. Additionally, output files are then representative of the solution AT its suffix iteration number (output_000001 is the state of the solution at time dt). However, if restart files are **not** used as an initial condition, then `TimeIter` is initialized to 0, and `time` to `0`. The computations for time-varying "things" are **off** by a timestep, and the output represents the solution AFTER its suffix iteration number (output_000000 is the state of the solution at time dt). More information is provided at [su2code/su2#2353](https://github.com/su2code/SU2/issues/2353). The punchline is that is it better to import a restart file as an initial condition always. This is also particularly important for restarted simulations. This PR adds documentation and guidance on this note.

Closes #42 